### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = "index.html"

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
 # Canvas2image #
+[![run on repl.it](http://repl.it/badge/github/hongru/canvas2image)](https://repl.it/github/hongru/canvas2image)
+
 a tool of saving or converting canvas to images
 
 ## Demo ##


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-canvas2image):

![image](https://i.imgur.com/UxtkO80.png)
